### PR TITLE
Add DomainAgent package

### DIFF
--- a/packages/domain-agent/README.md
+++ b/packages/domain-agent/README.md
@@ -1,0 +1,3 @@
+# Domain Agent
+
+A utility package for managing DNS records via supported registrars such as Namecheap. Intended for automating domain ownership verification for AT Protocol handles.

--- a/packages/domain-agent/package.json
+++ b/packages/domain-agent/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@forge/domain-agent",
+  "description": "Automated DNS configuration for AT Protocol handles.",
+  "version": "0.1.0",
+  "author": {
+    "name": "ÆForge",
+    "email": "hello@privateclient.ai"
+  },
+  "homepage": "https://privateclient.ai",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "https://ashashash.com/forge-os"
+  },
+  "keywords": [
+    "dns",
+    "domain",
+    "atproto",
+    "automation"
+  ],
+  "main": "./src/index.ts",
+  "types": "./.tsbuild/index.d.ts",
+  "files": [],
+  "scripts": {
+    "test": "yarn run -T jest",
+    "build": "yarn run -T tsx ../../internal/scripts/build-package.ts",
+    "lint": "yarn run -T tsx ../../internal/scripts/lint.ts"
+  },
+  "dependencies": {
+    "@tldraw/utils": "workspace:*",
+    "axios": "^1.6.7"
+  },
+  "devDependencies": {
+    "lazyrepo": "0.0.0-alpha.27"
+  },
+  "jest": {
+    "preset": "../../internal/config/jest/node/jest-preset.js",
+    "moduleNameMapper": {
+      "^~(.*)": "<rootDir>/src/$1"
+    }
+  }
+}

--- a/packages/domain-agent/src/index.ts
+++ b/packages/domain-agent/src/index.ts
@@ -1,0 +1,30 @@
+export interface DNSProvider {
+  addTxtRecord(host: string, name: string, value: string, ttl?: number): Promise<void>
+  removeTxtRecord(host: string, name: string): Promise<void>
+}
+
+export interface NamecheapCredentials {
+  apiUser: string
+  apiKey: string
+  clientIp: string
+}
+
+/**
+ * DomainAgent is responsible for configuring DNS records used for AT Protocol
+ * handle verification. In this minimal implementation, the agent accepts a DNS
+ * provider which abstracts the underlying registrar API.
+ */
+export class DomainAgent {
+  constructor(private provider: DNSProvider) {}
+
+  /**
+   * Ensure that the `_atproto` TXT record is set for the provided host.
+   * @param host The domain to configure
+   * @param did The DID to associate with the handle
+   */
+  async configureAtprotoRecord(host: string, did: string) {
+    const recordName = '_atproto'
+    await this.provider.removeTxtRecord(host, recordName)
+    await this.provider.addTxtRecord(host, recordName, `did=${did}`, 60)
+  }
+}

--- a/packages/domain-agent/src/namecheapProvider.ts
+++ b/packages/domain-agent/src/namecheapProvider.ts
@@ -1,0 +1,38 @@
+import axios from 'axios'
+import { DNSProvider, NamecheapCredentials } from './index'
+
+export class NamecheapProvider implements DNSProvider {
+  constructor(private creds: NamecheapCredentials) {}
+
+  private async request(command: string, params: Record<string, string>) {
+    const base = 'https://api.namecheap.com/xml.response'
+    const res = await axios.get(base, {
+      params: {
+        ApiUser: this.creds.apiUser,
+        ApiKey: this.creds.apiKey,
+        UserName: this.creds.apiUser,
+        ClientIp: this.creds.clientIp,
+        Command: command,
+        ...params,
+      },
+    })
+    if (res.status !== 200) throw new Error('Request failed')
+    return res.data
+  }
+
+  async addTxtRecord(host: string, name: string, value: string, ttl = 60) {
+    await this.request('namecheap.domains.dns.setHosts', {
+      SLD: host.split('.')[0],
+      TLD: host.split('.').slice(1).join('.'),
+      [`HostName1`]: name,
+      [`RecordType1`]: 'TXT',
+      [`Address1`]: value,
+      [`TTL1`]: ttl.toString(),
+    })
+  }
+
+  async removeTxtRecord(host: string, name: string) {
+    // Placeholder: would fetch existing records and remove matching one
+    // For brevity, this is left unimplemented
+  }
+}

--- a/packages/domain-agent/tsconfig.json
+++ b/packages/domain-agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../internal/config/tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", ".tsbuild*"],
+  "compilerOptions": {
+    "outDir": "./.tsbuild",
+    "rootDir": "src"
+  }
+}


### PR DESCRIPTION
## Summary
- add new `@forge/domain-agent` package
- stub out `DomainAgent` and `NamecheapProvider` for DNS automation

## Testing
- `yarn test` *(fails: could not fetch yarn packages)*

------
https://chatgpt.com/codex/tasks/task_b_68455414958483279d56365b46a529a3